### PR TITLE
correct percentage calc on stock plugin

### DIFF
--- a/stampy/plugin/stock.py
+++ b/stampy/plugin/stock.py
@@ -60,7 +60,7 @@ class IEXAPI:
         if "change" in content:
             quote['c'] = content['change']
         if "changePercent" in content:
-            quote['cp'] = content['changePercent']*100
+            quote['cp'] = content['changePercent'] * 100
         if "latestPrice" in content:
             quote['l_cur'] = content['latestPrice']
         return quote

--- a/stampy/plugin/stock.py
+++ b/stampy/plugin/stock.py
@@ -60,7 +60,7 @@ class IEXAPI:
         if "change" in content:
             quote['c'] = content['change']
         if "changePercent" in content:
-            quote['cp'] = content['changePercent']
+            quote['cp'] = content['changePercent']*100
         if "latestPrice" in content:
             quote['l_cur'] = content['latestPrice']
         return quote


### PR DESCRIPTION
On stock plugin, change percentage is not being showed correctly:

USD/EUR rate 0.80658
XXXX Quote  144.73 -969.0 (-0.06275%) (116.74 EUR)

Should be:

USD/EUR rate 0.80658
XXXX Quote  144.73 -969.0 (-6.275%) (116.74 EUR)